### PR TITLE
Add icon-based theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,23 @@
 <div class="max-w-4xl mx-auto p-6">
     <header class="flex justify-between items-center mb-10">
         <h1 class="text-3xl font-bold">Mony Ratha</h1>
-        <button onclick="toggleTheme()" aria-label="Toggle theme" class="text-sm border px-3 py-1 rounded hover:bg-gray-800">
-            Toggle Theme
+        <button onclick="toggleTheme()" aria-label="Toggle theme" class="text-sm border px-2 py-1 rounded hover:bg-gray-800">
+            <!-- Sun icon -->
+            <svg id="icon-sun" class="w-5 h-5 dark:hidden" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="5" />
+                <line x1="12" y1="1" x2="12" y2="3" />
+                <line x1="12" y1="21" x2="12" y2="23" />
+                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+                <line x1="1" y1="12" x2="3" y2="12" />
+                <line x1="21" y1="12" x2="23" y2="12" />
+                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+            </svg>
+            <!-- Moon icon -->
+            <svg id="icon-moon" class="w-5 h-5 hidden dark:block" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+            </svg>
         </button>
     </header>
 


### PR DESCRIPTION
## Summary
- swap out the text label for the theme toggle button and insert sun/moon icons

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841080f0310832d886a676854aa422b